### PR TITLE
Flesh out user implementation

### DIFF
--- a/lib/ex_launch_darkly/user.ex
+++ b/lib/ex_launch_darkly/user.ex
@@ -31,6 +31,6 @@ defmodule ExLaunchDarkly.User do
   def set_private_attribute_names(user, attribute_names),
     do: :eld_user.set_private_attribute_names(attribute_names, user)
 
-  @spec scrub(t(), list(attribute())) :: {t(), list(attribute())}
+  @spec scrub(t(), list(attribute()) | :all) :: {t(), list(attribute())}
   def scrub(user, attribute_names), do: :eld_user.scrub(user, attribute_names)
 end

--- a/lib/ex_launch_darkly/user.ex
+++ b/lib/ex_launch_darkly/user.ex
@@ -1,6 +1,36 @@
 defmodule ExLaunchDarkly.User do
+  @moduledoc """
+  User helpers for LaunchDarkly.
+
+  Usage
+
+  ```
+  user = User.new("a-slug")
+  # => %{key: "a-slug"}
+
+  User.set(user, :email, "user@email.com")
+  # => %{key: "a-slug", email: "user@email.com"}
+  ```
+  """
   @type t() :: :eld_user.user()
+  @type attribute() :: :eld_user.attribute()
 
   @spec new(String.t()) :: t()
   def new(key), do: :eld_user.new(key)
+
+  @spec new_from_map(t()) :: t()
+  def new_from_map(user_attributes), do: :eld_user.new_from_map(user_attributes)
+
+  @spec get(t(), attribute()) :: t()
+  def get(user, attribute), do: :eld_user.get(attribute, user)
+
+  @spec set(t(), attribute(), any()) :: t()
+  def set(user, attribute, value), do: :eld_user.set(attribute, value, user)
+
+  @spec set_private_attribute_names(t(), list(attribute())) :: t()
+  def set_private_attribute_names(user, attribute_names),
+    do: :eld_user.set_private_attribute_names(attribute_names, user)
+
+  @spec scrub(t(), list(attribute())) :: {t(), list(attribute())}
+  def scrub(user, attribute_names), do: :eld_user.scrub(user, attribute_names)
 end

--- a/test/ex_launch_darkly/user_test.exs
+++ b/test/ex_launch_darkly/user_test.exs
@@ -1,0 +1,67 @@
+defmodule ExLaunchDarkly.UserTest do
+  use ExUnit.Case
+  alias ExLaunchDarkly.User
+
+  @raw_user %{key: "test_key", email: "testuser@mail.com"}
+
+  setup do
+    user = User.new_from_map(@raw_user)
+    [user: user]
+  end
+
+  describe "new/1" do
+    test "it creates a new user from a key", _setup do
+      user = User.new(@raw_user.key)
+      assert user == %{key: @raw_user.key}
+    end
+  end
+
+  describe "get/2" do
+    test "it gets an attribute from a user", %{user: user} do
+      assert User.get(user, :email) == @raw_user.email
+    end
+  end
+
+  describe "set/3" do
+    test "it sets an attribute on a user", %{user: user} do
+      new_email = "newemail@mail.com"
+
+      assert User.set(user, :email, new_email) == %{email: new_email, key: @raw_user.key}
+    end
+  end
+
+  describe "set_private_attribute_names/2" do
+    test "it sets private attribute names", %{user: user} do
+      private_attributes = [:first_name, :last_name]
+      user_with_private_attributes = User.set_private_attribute_names(user, private_attributes)
+      assert user_with_private_attributes.private_attribute_names == private_attributes
+    end
+
+    test "it removes private_attributes if an empty list is given", %{user: user} do
+      private_attributes = [:first_name, :last_name]
+      user_with_private_attributes = User.set_private_attribute_names(user, private_attributes)
+
+      assert user_with_private_attributes.private_attribute_names == private_attributes
+
+      user_without_private_attributes =
+        User.set_private_attribute_names(user_with_private_attributes, [])
+
+      assert Map.get(user_without_private_attributes, :private_attribute_names) == nil
+    end
+  end
+
+  describe "scrub/2" do
+    test "it scrubs everything when passed :all", %{user: user} do
+      {user, keys} = user |> User.set(:last_name, "Bonk") |> User.scrub(:all)
+      assert user == %{key: @raw_user.key}
+      assert keys == ["last_name", "email"]
+    end
+
+    test "it scrubs specific keys", %{user: user} do
+      last_name = "Bonk"
+      {user, keys} = user |> User.set(:last_name, last_name) |> User.scrub([:email])
+      assert user == %{key: @raw_user.key, last_name: last_name}
+      assert keys == [:email]
+    end
+  end
+end


### PR DESCRIPTION
This PR finishes the User implementation wrapper. Since, it lends itself well to piping, I have rejigged the spec so the user is the first argument where applicable.


