### PR TITLE
Feature/ver bump

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 22.0.7
-elixir 1.9.2-otp-22
+erlang 22.2
+elixir 1.9.4-otp-22

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule ExLaunchDarkly.MixProject do
       {:credo, "~> 1.1.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.4", only: :dev, runtime: false},
       # Everything else
-      {:eld, github: "launchdarkly/erlang-server-sdk", tag: "1.0.0-alpha3"}
+      {:eld, github: "launchdarkly/erlang-server-sdk", tag: "1.0.0-alpha4"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExLaunchDarkly.MixProject do
   use Mix.Project
 
-  @version "0.0.5"
+  @version "0.0.6"
 
   def project do
     [

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,7 @@
   "cowlib": {:hex, :cowlib, "2.6.0", "8aa629f81a0fc189f261dc98a42243fa842625feea3c7ec56c48f4ccdb55490f", [:rebar3], [], "hexpm"},
   "credo": {:hex, :credo, "1.1.2", "02b6422f3e659eb74b05aca3c20c1d8da0119a05ee82577a82e6c2938bf29f81", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.6", "78e97d9c0ff1b5521dd68041193891aebebce52fc3b93463c0a6806874557d7d", [:mix], [{:erlex, "~> 0.2.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
-  "eld": {:git, "https://github.com/launchdarkly/erlang-server-sdk.git", "bd75a0b8ddcec8de453720d3a4b5c7092391b876", [tag: "1.0.0-alpha3"]},
+  "eld": {:git, "https://github.com/launchdarkly/erlang-server-sdk.git", "c56938943736a6102d23e9fe09bb1c0c1bc8f4cd", [tag: "1.0.0-alpha4"]},
   "erlex": {:hex, :erlex, "0.2.4", "23791959df45fe8f01f388c6f7eb733cc361668cbeedd801bf491c55a029917b", [:mix], [], "hexpm"},
   "gun": {:hex, :gun, "1.3.1", "1489fd96018431b89f401041a9ce0b02b45265247f0fdcf71273bf087c64ea4f", [:rebar3], [{:cowlib, "~> 2.6.0", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},


### PR DESCRIPTION
Updating to latest erlang-server-sdk release https://github.com/launchdarkly/erlang-server-sdk/pull/16

- bumped .tool-versions to match the rest of our repos