### PR TITLE
Add identify function wrapper to ExLaunchDarkly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A quick Elixir wrapper around the official LaunchDarkly [Erlang library](https:/
 ```elixir
 def deps do
   [
-    {:ex_launch_darkly, github: "pixelunion/exlixir-launch-darkly", tag: "v0.0.1"}
+    {:ex_launch_darkly, github: "pixelunion/elixir-launchdarkly", tag: "v0.0.7"}
   ]
 end
 ```
@@ -17,7 +17,7 @@ end
 Start your connection to LaunchDarkly on Application start.
 
 ```elixir
-ExLaunchDarkly.start(application.fetch_env!(:your_application, :launchdarkly_api_key)
+ExLaunchDarkly.App.start(application.fetch_env!(:your_application, :launchdarkly_api_key))
 ```
 
 Retrieve a variation.

--- a/lib/ex_launch_darkly.ex
+++ b/lib/ex_launch_darkly.ex
@@ -22,4 +22,10 @@ defmodule ExLaunchDarkly do
 
   @spec all_flags_state(User.t(), atom()) :: map()
   def all_flags_state(user, tag), do: :ldclient.all_flags_state(user, tag)
+
+  @spec identify(User.t()) :: :ok
+  def identify(user), do: :ldclient.identify(user)
+
+  @spec identify(User.t(), atom()) :: :ok
+  def identify(user, tag), do: :ldclient.identify(user, tag)
 end


### PR DESCRIPTION
This adds a wrapper function for `:ldclient.identify` to the ExLaunchDarkly module. 

`identify` is recommended for [prepopulating the user dashboard](https://docs.launchdarkly.com/sdk/server-side/erlang#identify). Including the function in the ExLaunchDarkly API addresses a common use case for devs adding it to their projects.

I also updated some bugs in the README. 😄 